### PR TITLE
fix: change trade limits from fiat to sats

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -146,8 +146,8 @@ Edit `config.json`:
   "relays": ["wss://relay.mostro.network"],
   "network": "mainnet",
   "limits": {
-    "max_trade_amount_fiat": 100,
-    "max_daily_volume_fiat": 500,
+    "max_trade_amount_sats": 50000,
+    "max_daily_volume_sats": 500000,
     "max_trades_per_day": 10,
     "cooldown_seconds": 300,
     "require_confirmation": true

--- a/config.example.json
+++ b/config.example.json
@@ -7,8 +7,8 @@
   ],
   "network": "mainnet",
   "limits": {
-    "max_trade_amount_fiat": 100,
-    "max_daily_volume_fiat": 500,
+    "max_trade_amount_sats": 50000,
+    "max_daily_volume_sats": 500000,
     "max_trades_per_day": 10,
     "cooldown_seconds": 300,
     "require_confirmation": true

--- a/config.example.json
+++ b/config.example.json
@@ -7,8 +7,8 @@
   ],
   "network": "mainnet",
   "limits": {
-    "max_trade_amount_sats": 50000,
-    "max_daily_volume_sats": 500000,
+    "max_trade_amount_sats": 100,
+    "max_daily_volume_sats": 100,
     "max_trades_per_day": 10,
     "cooldown_seconds": 300,
     "require_confirmation": true

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -6,8 +6,12 @@ import { readFileSync, existsSync } from "fs";
 import { join } from "path";
 
 export interface TradeLimits {
-  max_trade_amount_fiat: number;
-  max_daily_volume_fiat: number;
+  /** @deprecated Use max_trade_amount_sats instead */
+  max_trade_amount_fiat?: number;
+  /** @deprecated Use max_daily_volume_sats instead */
+  max_daily_volume_fiat?: number;
+  max_trade_amount_sats: number;
+  max_daily_volume_sats: number;
   max_trades_per_day: number;
   cooldown_seconds: number;
   require_confirmation: boolean;
@@ -27,8 +31,8 @@ const DEFAULT_CONFIG: MostroConfig = {
   relays: ["wss://relay.mostro.network", "wss://nos.lol"],
   network: "mainnet",
   limits: {
-    max_trade_amount_fiat: 100,
-    max_daily_volume_fiat: 500,
+    max_trade_amount_sats: 50000,    // ~$50 USD at $100k/BTC
+    max_daily_volume_sats: 500000,   // ~$500 USD at $100k/BTC
     max_trades_per_day: 10,
     cooldown_seconds: 300,
     require_confirmation: true,
@@ -75,8 +79,8 @@ export function validateConfig(config: MostroConfig): string[] {
   if (config.relays.length === 0) {
     errors.push("At least one relay is required");
   }
-  if (config.limits.max_trade_amount_fiat <= 0) {
-    errors.push("max_trade_amount_fiat must be positive");
+  if (config.limits.max_trade_amount_sats <= 0) {
+    errors.push("max_trade_amount_sats must be positive");
   }
   return errors;
 }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -82,5 +82,8 @@ export function validateConfig(config: MostroConfig): string[] {
   if (config.limits.max_trade_amount_sats <= 0) {
     errors.push("max_trade_amount_sats must be positive");
   }
+  if (config.limits.max_daily_volume_sats <= 0) {
+    errors.push("max_daily_volume_sats must be positive");
+  }
   return errors;
 }

--- a/lib/safety.ts
+++ b/lib/safety.ts
@@ -54,7 +54,7 @@ interface TradeState {
   last_trade_at?: string;
 }
 
-function loadState(): TradeState {
+export function loadState(): TradeState {
   if (!existsSync(STATE_FILE)) return { daily_volume: {}, daily_trades: {} };
   try {
     return JSON.parse(readFileSync(STATE_FILE, "utf-8"));
@@ -68,7 +68,7 @@ function saveState(state: TradeState): void {
   writeFileSync(STATE_FILE, JSON.stringify(state, null, 2), { mode: 0o600 });
 }
 
-function todayKey(): string {
+export function todayKey(): string {
   return new Date().toISOString().split("T")[0];
 }
 

--- a/lib/safety.ts
+++ b/lib/safety.ts
@@ -81,28 +81,30 @@ export interface LimitCheckResult {
 
 /**
  * Check if a trade is within configured limits
+ * @param limits - Trade limits configuration
+ * @param satsAmount - Amount of the trade in satoshis
  */
 export function checkLimits(
   limits: TradeLimits,
-  fiatAmount: number
+  satsAmount: number
 ): LimitCheckResult {
   const state = loadState();
   const today = todayKey();
 
-  // Check single trade amount
-  if (fiatAmount > limits.max_trade_amount_fiat) {
+  // Check single trade amount (in sats)
+  if (satsAmount > limits.max_trade_amount_sats) {
     return {
       allowed: false,
-      reason: `Trade amount ${fiatAmount} exceeds max ${limits.max_trade_amount_fiat}`,
+      reason: `Trade amount ${satsAmount} sats exceeds max ${limits.max_trade_amount_sats} sats`,
     };
   }
 
-  // Check daily volume
+  // Check daily volume (in sats)
   const todayVolume = state.daily_volume[today] ?? 0;
-  if (todayVolume + fiatAmount > limits.max_daily_volume_fiat) {
+  if (todayVolume + satsAmount > limits.max_daily_volume_sats) {
     return {
       allowed: false,
-      reason: `Would exceed daily volume limit: ${todayVolume + fiatAmount} > ${limits.max_daily_volume_fiat}`,
+      reason: `Would exceed daily volume limit: ${todayVolume + satsAmount} > ${limits.max_daily_volume_sats} sats`,
     };
   }
 
@@ -133,12 +135,13 @@ export function checkLimits(
 
 /**
  * Record a trade execution for limit tracking
+ * @param satsAmount - Amount of the trade in satoshis
  */
-export function recordTrade(fiatAmount: number): void {
+export function recordTrade(satsAmount: number): void {
   const state = loadState();
   const today = todayKey();
 
-  state.daily_volume[today] = (state.daily_volume[today] ?? 0) + fiatAmount;
+  state.daily_volume[today] = (state.daily_volume[today] ?? 0) + satsAmount;
   state.daily_trades[today] = (state.daily_trades[today] ?? 0) + 1;
   state.last_trade_at = new Date().toISOString();
 

--- a/scripts/auto-trade.ts
+++ b/scripts/auto-trade.ts
@@ -120,7 +120,7 @@ async function executeDCA(
   const btcPrice = await fetchBtcPrice(strategy.currency, config.price_api);
   const estimatedSats = btcPrice && btcPrice > 0
     ? Math.round((strategy.fiat_amount / btcPrice) * 1e8)
-    : strategy.fiat_amount * 1000; // fallback
+    : Math.round(strategy.fiat_amount * 1000); // fallback
 
   // Check limits (in sats)
   const limitCheck = checkLimits(config.limits, estimatedSats);
@@ -330,7 +330,7 @@ async function executeMarketMaker(
   const btcPrice = await fetchBtcPrice(strategy.currency, config.price_api);
   const estimatedSats = btcPrice && btcPrice > 0
     ? Math.round((strategy.fiat_amount / btcPrice) * 1e8)
-    : strategy.fiat_amount * 1000; // fallback
+    : Math.round(strategy.fiat_amount * 1000); // fallback
 
   // Check limits (need room for both buy and sell)
   const limitCheck = checkLimits(config.limits, estimatedSats * 2);

--- a/scripts/create-order.ts
+++ b/scripts/create-order.ts
@@ -173,8 +173,8 @@ async function main() {
         console.log(`   Status: ${order?.status}`);
         console.log(`   Amount: ${order?.fiat_amount} ${order?.fiat_code}`);
 
-        // Use actual sats from order response, or estimate
-        const actualSats = order?.amount ?? estimatedSats;
+        // Use actual sats from order response, or estimate (market-price orders have amount=0)
+        const actualSats = order?.amount || estimatedSats;
         recordTrade(actualSats);
         auditLog({
           timestamp: new Date().toISOString(),

--- a/scripts/create-order.ts
+++ b/scripts/create-order.ts
@@ -21,7 +21,7 @@ import {
   type OrderKind,
 } from "../lib/protocol.js";
 import { getOrCreateKeys } from "../lib/keys.js";
-import { checkLimits, auditLog, recordTrade } from "../lib/safety.js";
+import { checkLimits, auditLog, recordTrade, fetchBtcPrice } from "../lib/safety.js";
 
 function parseArgs() {
   const args = process.argv.slice(2);
@@ -61,8 +61,20 @@ async function main() {
     process.exit(1);
   }
 
-  // Safety checks
-  const limitCheck = checkLimits(config.limits, opts.fiat_amount);
+  // Estimate sats from fiat for limit checking
+  const btcPrice = await fetchBtcPrice(opts.currency, config.price_api);
+  let estimatedSats = 0;
+  if (btcPrice && btcPrice > 0) {
+    // Convert fiat to BTC, then to sats
+    estimatedSats = Math.round((opts.fiat_amount / btcPrice) * 1e8);
+  } else {
+    // If we can't get price, use a conservative estimate (assume $100k BTC)
+    console.warn("⚠️  Could not fetch BTC price, using conservative estimate for limit check");
+    estimatedSats = opts.fiat_amount * 1000; // ~1000 sats per dollar at $100k
+  }
+
+  // Safety checks (using sats)
+  const limitCheck = checkLimits(config.limits, estimatedSats);
   if (!limitCheck.allowed) {
     console.error(`🚫 Trade blocked: ${limitCheck.reason}`);
     auditLog({
@@ -161,7 +173,9 @@ async function main() {
         console.log(`   Status: ${order?.status}`);
         console.log(`   Amount: ${order?.fiat_amount} ${order?.fiat_code}`);
 
-        recordTrade(opts.fiat_amount);
+        // Use actual sats from order response, or estimate
+        const actualSats = order?.amount ?? estimatedSats;
+        recordTrade(actualSats);
         auditLog({
           timestamp: new Date().toISOString(),
           action: "create-order",
@@ -169,6 +183,7 @@ async function main() {
           fiat_amount: opts.fiat_amount,
           fiat_code: opts.currency,
           result: "success",
+          details: `${actualSats} sats`,
         });
       } else if (kind.action === "cant-do") {
         console.error(`❌ Mostro rejected the order: ${JSON.stringify(kind.payload)}`);


### PR DESCRIPTION
## Summary

Trade limits are now specified in satoshis instead of fiat units. This ensures consistent risk management across all currencies.

## Problem

Previously, `max_trade_amount_fiat: 100` would block a 200 CUP order (~$1.60 USD) while allowing a 100 USD order (~6250x more value). This made the safety limits ineffective for non-USD currencies.

## Changes

- **config**: `max_trade_amount_sats`, `max_daily_volume_sats` (replaces `_fiat` versions)
- **safety.ts**: `checkLimits()` and `recordTrade()` now use sats
- **create-order.ts**: estimates sats from fiat via price API before checking limits
- **auto-trade.ts**: updated all strategies (DCA, limit, market-maker) to use sats
- **SKILL.md**: updated documentation

## Migration

Users should update their `config.json`:

```diff
"limits": {
-  "max_trade_amount_fiat": 100,
-  "max_daily_volume_fiat": 500,
+  "max_trade_amount_sats": 50000,
+  "max_daily_volume_sats": 500000,
   ...
}
```

## Testing

- [x] TypeScript compiles without errors
- [x] Limit checks now work consistently across currencies

Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Limits and trade accounting now use satoshi amounts; when only fiat is provided the app estimates sats using BTC price with a conservative fallback.
  * Audit and trade records include sats values for clearer tracking.

* **Chores**
  * Configuration and validation updated to reflect sats-based limits while keeping legacy fiat keys supported for compatibility.
  * Messaging and warnings updated to reference sats units.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->